### PR TITLE
Prevent payload dump to be serialized

### DIFF
--- a/src/FluxEvent/PayloadProcessor.php
+++ b/src/FluxEvent/PayloadProcessor.php
@@ -35,7 +35,7 @@ class PayloadProcessor
                     }
 
                     if (!array_key_exists($oldImage, $processedPayload->namespaces)) {
-                        $namespace = $this->findNamespace($$payload, $oldImage);
+                        $namespace = $this->findNamespace($payload, $oldImage);
                         $processedPayload->namespaces[$oldImage] = $namespace;
                     }
                 }

--- a/src/FluxEvent/PayloadProcessor.php
+++ b/src/FluxEvent/PayloadProcessor.php
@@ -35,7 +35,7 @@ class PayloadProcessor
                     }
 
                     if (!array_key_exists($oldImage, $processedPayload->namespaces)) {
-                        $namespace = $this->findNamespace($json, $oldImage);
+                        $namespace = $this->findNamespace($$payload, $oldImage);
                         $processedPayload->namespaces[$oldImage] = $namespace;
                     }
                 }
@@ -52,9 +52,8 @@ class PayloadProcessor
         return $processedPayload;
     }
 
-    private function findNamespace(string $json, string $image): string
+    private function findNamespace(object $payload, string $image): string
     {
-        $payload = json_decode($json);
         foreach ($payload->Event->metadata->result as $workload => $result) {
             if (!empty($result->PerContainer)) {
                 foreach ($result->PerContainer as $container) {
@@ -67,10 +66,8 @@ class PayloadProcessor
 
         // If no namespace was found, fallback to "unknown", but log the payload for investigation.
         $logger = new IoLogger();
-        $logger->debug(
-            'Could not determine namespace from received payload.',
-            $json
-        );
+        $logger->debug('Could not determine namespace from received payload.');
+        $logger->debug(json_encode($payload, JSON_PRETTY_PRINT));
 
         return 'unknown';
     }


### PR DESCRIPTION
`$context` parameter of `IoLogger->debug()` gets serialized. So, let's not use that, and use 2 separate `debug()` calls instead.